### PR TITLE
Add watcher

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,6 +12,7 @@ rules:
   - namespaces
   verbs:
   - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,9 +11,7 @@ rules:
   resources:
   - namespaces
   verbs:
-  - get
   - list
-  - watch
 - apiGroups:
   - apps
   resources:

--- a/controllers/watcher.go
+++ b/controllers/watcher.go
@@ -61,12 +61,14 @@ func (r *Watcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result,
 	// The first thing we need to do is determine if the deployment has the opt-in label and if it's set to true
 	// If neither of these conditions is met, then we won't reconcile.
 	labels := deployment.GetLabels()
-	if v, found := labels["scaler/opt-in"]; found {
-		if v != "true" {
-			log.Info("Opted-out deployment. Doing nothing")
-			return ctrl.Result{}, nil
+	for k := range reconciler.OptInLabel {
+		if v, found := labels[k]; found {
+			if v != "true" {
+				log.Info("Opted-out deployment. Doing nothing")
+				return ctrl.Result{}, nil
+			}
+			break
 		}
-	} else {
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/watcher.go
+++ b/controllers/watcher.go
@@ -38,7 +38,7 @@ type Watcher struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch;update;
 
 // WatchForDeployments creates watcher for Chaos Runner Pod
@@ -51,7 +51,7 @@ func (r *Watcher) WatchForDeployments(client client.Client, c controller.Control
 func (r *Watcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 
 	log := r.Log.
-		WithValues("reconciler kind", "Wachter").
+		WithValues("reconciler kind", "Watcher").
 		WithValues("reconciler namespace", req.Namespace).
 		WithValues("reconciler object", req.Name)
 

--- a/controllers/watcher.go
+++ b/controllers/watcher.go
@@ -1,5 +1,4 @@
 /*
-Copyright 2019 LitmusChaos Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/controllers/watcher.go
+++ b/controllers/watcher.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2019 LitmusChaos Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"github.com/containersol/prescale-operator/internal/reconciler"
+	"github.com/containersol/prescale-operator/internal/states"
+
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Watcher reconciles a ScalingState object
+type Watcher struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// WatchForRunnerPod creates watcher for Chaos Runner Pod
+func (r *Watcher) WatchForRunnerPod(client client.Client, c controller.Controller) error {
+
+	return c.Watch(&source.Kind{Type: &v1.Deployment{}}, &handler.EnqueueRequestForObject{})
+}
+
+func (r *Watcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+
+	log := r.Log.
+		WithValues("reconciler kind", "Wachter").
+		WithValues("reconciler namespace", req.Namespace).
+		WithValues("reconciler object", req.Name)
+
+		// Fetch the deployment
+	deployment := v1.Deployment{}
+	err := r.Client.Get(ctx, req.NamespacedName, &deployment)
+	if err != nil {
+		log.Error(err, "Failed to handle event")
+		return ctrl.Result{}, err
+	}
+
+	stateDefinitions, err := states.GetClusterScalingStateDefinitions(ctx, r.Client)
+	if err != nil {
+		// If we encounter an error trying to retrieve the state definitions,
+		// we will not be able to compute anything else.
+		log.Error(err, "Failed to get ClusterStateDefinitions")
+		return ctrl.Result{}, err
+	}
+
+	finalState, err := reconciler.GetAppliedState(ctx, r.Client, req.Namespace, stateDefinitions, states.State{})
+	if err != nil {
+		log.Error(err, "Cannot determine applied state for namespace")
+	}
+
+	labels := deployment.GetLabels()
+	if v, found := labels["scaler/opt-in"]; found {
+		if v != "true" {
+			log.Info("Opted-out deployment. Doing nothing")
+			return ctrl.Result{}, nil
+		}
+	} else {
+		return ctrl.Result{}, nil
+	}
+
+	err = reconciler.ReconcileDeployment(ctx, r.Client, deployment, finalState)
+
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Reconciliation loop completed successfully")
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Watcher) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1.Deployment{}).
+		Complete(r)
+}

--- a/controllers/watcher.go
+++ b/controllers/watcher.go
@@ -41,7 +41,7 @@ type Watcher struct {
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch;update;
 
-// WatchForDeployments creates watcher for Chaos Runner Pod
+// WatchForDeployments creates watcher for the deployment objects
 func (r *Watcher) WatchForDeployments(client client.Client, c controller.Controller) error {
 
 	return c.Watch(&source.Kind{Type: &v1.Deployment{}}, &handler.EnqueueRequestForObject{})

--- a/controllers/watcher.go
+++ b/controllers/watcher.go
@@ -38,7 +38,7 @@ type Watcher struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;watch;
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch;update;
 
 // WatchForDeployments creates watcher for the deployment objects

--- a/controllers/watcher.go
+++ b/controllers/watcher.go
@@ -38,6 +38,9 @@ type Watcher struct {
 	Scheme *runtime.Scheme
 }
 
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch;update;
+
 // WatchForDeployments creates watcher for Chaos Runner Pod
 func (r *Watcher) WatchForDeployments(client client.Client, c controller.Controller) error {
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -71,7 +71,7 @@ func ReconcileDeployment(ctx context.Context, _client client.Client, deployment 
 		log.WithValues("set states", stateReplicas).
 			WithValues("namespace state", state.Name).
 			Info("State could not be found")
-		return client.IgnoreNotFound(err)
+		return err
 	}
 	log.Info("Updating deployment replicas for state", "replicas", stateReplica.Replicas)
 	deployment.Spec.Replicas = &stateReplica.Replicas

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -71,7 +71,7 @@ func ReconcileDeployment(ctx context.Context, _client client.Client, deployment 
 		log.WithValues("set states", stateReplicas).
 			WithValues("namespace state", state.Name).
 			Info("State could not be found")
-		return err
+		return client.IgnoreNotFound(err)
 	}
 	log.Info("Updating deployment replicas for state", "replicas", stateReplica.Replicas)
 	deployment.Spec.Replicas = &stateReplica.Replicas

--- a/internal/validations/label_validation.go
+++ b/internal/validations/label_validation.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 )
 
+// OptinLabelExists checks if the opt-in label exists in the target object and returns its value
 func OptinLabelExists(deployment v1.Deployment) (bool, error) {
 
 	var optinlabel bool
@@ -18,5 +19,5 @@ func OptinLabelExists(deployment v1.Deployment) (bool, error) {
 			return optinlabel, err
 		}
 	}
-	return optinlabel, errors.New("Not Found")
+	return optinlabel, errors.New("Opt-in label was not found")
 }

--- a/internal/validations/label_validation.go
+++ b/internal/validations/label_validation.go
@@ -1,0 +1,22 @@
+package validations
+
+import (
+	"errors"
+	"github.com/containersol/prescale-operator/internal/reconciler"
+	v1 "k8s.io/api/apps/v1"
+	"strconv"
+)
+
+func OptinLabelExists(deployment v1.Deployment) (bool, error) {
+
+	var optinlabel bool
+
+	labels := deployment.GetLabels()
+	for k := range reconciler.OptInLabel {
+		if v, found := labels[k]; found {
+			optinlabel, err := strconv.ParseBool(v)
+			return optinlabel, err
+		}
+	}
+	return optinlabel, errors.New("Not Found")
+}

--- a/internal/validations/label_validation.go
+++ b/internal/validations/label_validation.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 )
 
+const LabelNotFound = "Opt-in label was not found"
+
 // OptinLabelExists checks if the opt-in label exists in the target object and returns its value
 func OptinLabelExists(deployment v1.Deployment) (bool, error) {
 
@@ -19,5 +21,5 @@ func OptinLabelExists(deployment v1.Deployment) (bool, error) {
 			return optinlabel, err
 		}
 	}
-	return optinlabel, errors.New("Opt-in label was not found")
+	return optinlabel, errors.New(LabelNotFound)
 }

--- a/main.go
+++ b/main.go
@@ -102,6 +102,14 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "ScalingState")
 		os.Exit(1)
 	}
+	if err = (&controllers.Watcher{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("Watcher"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ScalingState")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {


### PR DESCRIPTION
Implementing watcher for deployment objects. It adds a validation label function to check the existence of the opt-in label.
The watcher is implemented as a separate controller and will only reconcile the object in case of the label exists and is set to true.
To do that, it watches all deployments across all namespaces by using the watch verb in the cluster role.

Once we start watching different resources, the structure of the watcher will also change a bit as a controller can watch only 1 primary resource. 
However for the current state of the operator, this controller is working as expected.