### PR TITLE
Test okd workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ env:
   CR_PAT: ${{ secrets.CR_PAT }}
   DH_USER: ${{ secrets.DOCKERHUB_PUSH_USERNAME }}
   DH_TOKEN: ${{ secrets.DOCKERHUB_PUSH_PASS }}
+  OKD_PASSWORD: ${{ secrets.OKD_PASSWORD }}
 
 jobs:
   tests-and-build:
@@ -66,14 +67,17 @@ jobs:
       #   if: ${{ always() }}
       #   run: kind delete cluster
 
-      - name: Setup OpenShift
-        uses: manusa/actions-setup-openshift@v1.1.2
-        with:
-          oc version: 'v3.11.0'
-          github token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Setup OpenShift
+      #   uses: manusa/actions-setup-openshift@v1.1.2
+      #   with:
+      #     oc version: 'v3.11.0'
+      #     github token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Interact with the cluster
-        run: oc cluster status
+      # - name: Interact with the cluster
+      #   run: oc cluster status
+
+      - name: Cluster login
+        run: oc login -u kubeadmin -p ${{ env.OKD_PASSWORD }} https://api.prescaling-operator-dev.openshift.csol.cloud:6443
 
       - name: Run tests for Openshift
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,27 +45,27 @@ jobs:
           sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
           export PATH=$PATH:/usr/local/kubebuilder/bin
 
-      # - name: Installing Prerequisites (KinD Cluster)
-      #   uses: engineerd/setup-kind@v0.5.0
-      #   with:
-      #       version: "v0.7.0"
+      - name: Installing Prerequisites (KinD Cluster)
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+            version: "v0.7.0"
 
-      # - name: Configuring and testing kind Installation
-      #   run: |
-      #     kubectl cluster-info --context kind-kind
-      #     kind get kubeconfig --internal >$HOME/.kube/config
-      #     kubectl get nodes
+      - name: Configuring and testing kind Installation
+        run: |
+          kubectl cluster-info --context kind-kind
+          kind get kubeconfig --internal >$HOME/.kube/config
+          kubectl get nodes
  
-      # - name: Run tests for Kubernetes
-      #   run: |
-      #     make test
+      - name: Run tests for Kubernetes
+        run: |
+          make test
 
-      # - name: Interact with the cluster
-      #   run: kubectl get ns
+      - name: Interact with the cluster
+        run: kubectl get ns
 
-      # - name: Deleting KinD cluster
-      #   if: ${{ always() }}
-      #   run: kind delete cluster
+      - name: Deleting KinD cluster
+        if: ${{ always() }}
+        run: kind delete cluster
 
       # - name: Setup OpenShift
       #   uses: manusa/actions-setup-openshift@v1.1.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - test-okd-workflow
+      - main
   release:
     types:
       - edited
@@ -56,14 +56,10 @@ jobs:
           kind get kubeconfig --internal >$HOME/.kube/config
           kubectl get nodes
           kubectl create ns e2e-tests
-          kubectl config set-context --current --namespace=e2e-tests 
  
       - name: Run tests for Kubernetes
         run: |
           make test
-
-      - name: Interact with the cluster
-        run: kubectl get ns
 
       - name: Deleting KinD cluster
         if: ${{ always() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,37 +44,42 @@ jobs:
           sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
           export PATH=$PATH:/usr/local/kubebuilder/bin
 
-      - name: Installing Prerequisites (KinD Cluster)
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-            version: "v0.7.0"
+      # - name: Installing Prerequisites (KinD Cluster)
+      #   uses: engineerd/setup-kind@v0.5.0
+      #   with:
+      #       version: "v0.7.0"
 
-      - name: Configuring and testing kind Installation
-        run: |
-          kubectl cluster-info --context kind-kind
-          kind get kubeconfig --internal >$HOME/.kube/config
-          kubectl get nodes
+      # - name: Configuring and testing kind Installation
+      #   run: |
+      #     kubectl cluster-info --context kind-kind
+      #     kind get kubeconfig --internal >$HOME/.kube/config
+      #     kubectl get nodes
  
-      - name: Run tests for Kubernetes
-        run: |
-          make test
+      # - name: Run tests for Kubernetes
+      #   run: |
+      #     make test
 
-      - name: Deleting KinD cluster
-        if: ${{ always() }}
-        run: kind delete cluster
+      # - name: Deleting KinD cluster
+      #   if: ${{ always() }}
+      #   run: kind delete cluster
 
       - name: Setup OpenShift
         uses: manusa/actions-setup-openshift@v1.1.2
         with:
-          oc version: 'v3.11.0'
+          oc version: 'v4.7.0'
           github token: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Interact with the cluster
         run: oc cluster status
 
-      - name: Run tests for Openshift
+      - name: Test cluster access
         run: |
-          make test
+          oc get projects
+          oc get deployments
+
+      # - name: Run tests for Openshift
+      #   run: |
+      #     make test
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,27 +45,29 @@ jobs:
           sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
           export PATH=$PATH:/usr/local/kubebuilder/bin
 
-      # - name: Installing Prerequisites (KinD Cluster)
-      #   uses: engineerd/setup-kind@v0.5.0
-      #   with:
-      #       version: "v0.7.0"
+      - name: Installing Prerequisites (KinD Cluster)
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+            version: "v0.7.0"
 
-      # - name: Configuring and testing kind Installation
-      #   run: |
-      #     kubectl cluster-info --context kind-kind
-      #     kind get kubeconfig --internal >$HOME/.kube/config
-      #     kubectl get nodes
+      - name: Configuring and testing kind Installation
+        run: |
+          kubectl cluster-info --context kind-kind
+          kind get kubeconfig --internal >$HOME/.kube/config
+          kubectl get nodes
+          kubectl create ns e2e-tests
+          kubectl config set-context --current --namespace=e2e-tests 
  
-      # - name: Run tests for Kubernetes
-      #   run: |
-      #     make test
+      - name: Run tests for Kubernetes
+        run: |
+          make test
 
-      # - name: Interact with the cluster
-      #   run: kubectl get ns
+      - name: Interact with the cluster
+        run: kubectl get ns
 
-      # - name: Deleting KinD cluster
-      #   if: ${{ always() }}
-      #   run: kind delete cluster
+      - name: Deleting KinD cluster
+        if: ${{ always() }}
+        run: kind delete cluster
 
       - name: OKD Cluster login
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,14 +44,6 @@ jobs:
           sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
           export PATH=$PATH:/usr/local/kubebuilder/bin
 
-      - name: Setup OpenShift
-        uses: manusa/actions-setup-openshift@v1.1.2
-        with:
-          oc version: 'v3.11.0'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Interact with the cluster
-        run: oc cluster status
-
       - name: Installing Prerequisites (KinD Cluster)
         uses: engineerd/setup-kind@v0.5.0
         with:
@@ -62,14 +54,27 @@ jobs:
           kubectl cluster-info --context kind-kind
           kind get kubeconfig --internal >$HOME/.kube/config
           kubectl get nodes
-
-      - name: Run tests
+ 
+      - name: Run tests for Kubernetes
         run: |
           make test
- 
+
       - name: Deleting KinD cluster
         if: ${{ always() }}
         run: kind delete cluster
+
+      - name: Setup OpenShift
+        uses: manusa/actions-setup-openshift@v1.1.2
+        with:
+          oc version: 'v3.11.0'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Interact with the cluster
+        run: oc cluster status
+
+      - name: Run tests for Openshift
+        run: |
+          make test
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup OpenShift
         uses: manusa/actions-setup-openshift@v1.1.2
         with:
-          oc version: 'v4.7.0'
+          oc version: 'v4.3.0'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Interact with the cluster

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,43 +44,40 @@ jobs:
           sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
           export PATH=$PATH:/usr/local/kubebuilder/bin
 
-      - name: Installing Prerequisites (KinD Cluster)
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-            version: "v0.7.0"
+      # - name: Installing Prerequisites (KinD Cluster)
+      #   uses: engineerd/setup-kind@v0.5.0
+      #   with:
+      #       version: "v0.7.0"
 
-      - name: Configuring and testing kind Installation
-        run: |
-          kubectl cluster-info --context kind-kind
-          kind get kubeconfig --internal >$HOME/.kube/config
-          kubectl get nodes
+      # - name: Configuring and testing kind Installation
+      #   run: |
+      #     kubectl cluster-info --context kind-kind
+      #     kind get kubeconfig --internal >$HOME/.kube/config
+      #     kubectl get nodes
  
       # - name: Run tests for Kubernetes
       #   run: |
       #     make test
 
-      - name: Interact with the cluster
-        run: kubectl get ns
+      # - name: Interact with the cluster
+      #   run: kubectl get ns
 
-      - name: Deleting KinD cluster
-        if: ${{ always() }}
-        run: kind delete cluster
+      # - name: Deleting KinD cluster
+      #   if: ${{ always() }}
+      #   run: kind delete cluster
 
       - name: Setup OpenShift
         uses: manusa/actions-setup-openshift@v1.1.2
         with:
-          oc version: 'v4.7.0'
+          oc version: 'v3.11.0'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Interact with the cluster
         run: oc cluster status
 
-      - name: Test cluster access
-        run: oc get projects
-
-      # - name: Run tests for Openshift
-      #   run: |
-      #     make test
+      - name: Run tests for Openshift
+        run: |
+          make test
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup OpenShift
         uses: manusa/actions-setup-openshift@v1.1.2
         with:
-          oc version: 'v4.3.0'
+          oc version: 'v3.11.0'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Interact with the cluster

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ env:
   CR_PAT: ${{ secrets.CR_PAT }}
   DH_USER: ${{ secrets.DOCKERHUB_PUSH_USERNAME }}
   DH_TOKEN: ${{ secrets.DOCKERHUB_PUSH_PASS }}
-  OKD_PASSWORD: ${{ secrets.OKD_PASSWORD }}
+  OKD_GITHUB_TOKEN: ${{ secrets.OKD_GITHUB_TOKEN }}
 
 jobs:
   tests-and-build:
@@ -45,39 +45,31 @@ jobs:
           sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
           export PATH=$PATH:/usr/local/kubebuilder/bin
 
-      - name: Installing Prerequisites (KinD Cluster)
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-            version: "v0.7.0"
-
-      - name: Configuring and testing kind Installation
-        run: |
-          kubectl cluster-info --context kind-kind
-          kind get kubeconfig --internal >$HOME/.kube/config
-          kubectl get nodes
- 
-      - name: Run tests for Kubernetes
-        run: |
-          make test
-
-      - name: Interact with the cluster
-        run: kubectl get ns
-
-      - name: Deleting KinD cluster
-        if: ${{ always() }}
-        run: kind delete cluster
-
-      # - name: Setup OpenShift
-      #   uses: manusa/actions-setup-openshift@v1.1.2
+      # - name: Installing Prerequisites (KinD Cluster)
+      #   uses: engineerd/setup-kind@v0.5.0
       #   with:
-      #     oc version: 'v3.11.0'
-      #     github token: ${{ secrets.GITHUB_TOKEN }}
+      #       version: "v0.7.0"
+
+      # - name: Configuring and testing kind Installation
+      #   run: |
+      #     kubectl cluster-info --context kind-kind
+      #     kind get kubeconfig --internal >$HOME/.kube/config
+      #     kubectl get nodes
+ 
+      # - name: Run tests for Kubernetes
+      #   run: |
+      #     make test
 
       # - name: Interact with the cluster
-      #   run: oc cluster status
+      #   run: kubectl get ns
 
-      - name: Cluster login
-        run: oc login -u kubeadmin -p ${{ env.OKD_PASSWORD }}  --insecure-skip-tls-verify https://api.prescaling-operator-dev.openshift.csol.cloud:6443
+      # - name: Deleting KinD cluster
+      #   if: ${{ always() }}
+      #   run: kind delete cluster
+
+      - name: OKD Cluster login
+        run: |
+          oc login https://api.prescaling-operator-dev.openshift.csol.cloud:6443 --token='${{ env.OKD_GITHUB_TOKEN }}'
 
       - name: Run tests for Openshift
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: OKD Cluster login
         run: |
-          oc login https://api.prescaling-operator-dev.openshift.csol.cloud:6443 --token='${{ env.OKD_GITHUB_TOKEN }}'
+          oc login https://api.prescaling-operator-dev.openshift.csol.cloud:6443 --token='${{ env.OKD_GITHUB_TOKEN }}' --insecure-skip-tls-verify
 
       - name: Run tests for Openshift
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,38 +44,39 @@ jobs:
           sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
           export PATH=$PATH:/usr/local/kubebuilder/bin
 
-      # - name: Installing Prerequisites (KinD Cluster)
-      #   uses: engineerd/setup-kind@v0.5.0
-      #   with:
-      #       version: "v0.7.0"
+      - name: Installing Prerequisites (KinD Cluster)
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+            version: "v0.7.0"
 
-      # - name: Configuring and testing kind Installation
-      #   run: |
-      #     kubectl cluster-info --context kind-kind
-      #     kind get kubeconfig --internal >$HOME/.kube/config
-      #     kubectl get nodes
+      - name: Configuring and testing kind Installation
+        run: |
+          kubectl cluster-info --context kind-kind
+          kind get kubeconfig --internal >$HOME/.kube/config
+          kubectl get nodes
  
       # - name: Run tests for Kubernetes
       #   run: |
       #     make test
 
-      # - name: Deleting KinD cluster
-      #   if: ${{ always() }}
-      #   run: kind delete cluster
+      - name: Interact with the cluster
+        run: kubectl get ns
+
+      - name: Deleting KinD cluster
+        if: ${{ always() }}
+        run: kind delete cluster
 
       - name: Setup OpenShift
         uses: manusa/actions-setup-openshift@v1.1.2
         with:
-          oc version: 'v3.11.0'
+          oc version: 'v4.7.0'
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Interact with the cluster
         run: oc cluster status
 
       - name: Test cluster access
-        run: |
-          oc get projects
-          oc get deployments
+        run: oc get projects
 
       # - name: Run tests for Openshift
       #   run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
       #   run: oc cluster status
 
       - name: Cluster login
-        run: oc login -u kubeadmin -p ${{ env.OKD_PASSWORD }} https://api.prescaling-operator-dev.openshift.csol.cloud:6443
+        run: oc login -u kubeadmin -p ${{ env.OKD_PASSWORD }}  --insecure-skip-tls-verify https://api.prescaling-operator-dev.openshift.csol.cloud:6443
 
       - name: Run tests for Openshift
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - test-okd-workflow
   release:
     types:
       - edited
@@ -44,6 +44,13 @@ jobs:
           sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
           export PATH=$PATH:/usr/local/kubebuilder/bin
 
+      - name: Setup OpenShift
+        uses: manusa/actions-setup-openshift@v1.1.2
+        with:
+          oc version: 'v3.11.0'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Interact with the cluster
+        run: oc cluster status
 
       - name: Installing Prerequisites (KinD Cluster)
         uses: engineerd/setup-kind@v0.5.0

--- a/internal/e2e/deployment_watch_controller_test.go
+++ b/internal/e2e/deployment_watch_controller_test.go
@@ -28,7 +28,7 @@ var _ = Describe("e2e Test for the Deployment Watch Controller", func() {
 
 	var key = types.NamespacedName{
 		Name:      "test",
-		Namespace: "default",
+		Namespace: "e2e-tests",
 	}
 
 	BeforeEach(func() {


### PR DESCRIPTION
Executing tests against our OKD GCP cluster on a dedicated namespace. Same for KIND.
As a future enhancement, we can try to split the testing a bit. First execute the integration tests once, then Kubernetes and then Openshift. This will reduce the time it's needed to execute the suite. It will require some minor refactoring on the test code though.