### PR TITLE
Events generation

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - list

--- a/controllers/clusterscalingstate_controller.go
+++ b/controllers/clusterscalingstate_controller.go
@@ -99,10 +99,10 @@ func (r *ClusterScalingStateReconciler) Reconcile(ctx context.Context, req ctrl.
 	err = r.Get(ctx, req.NamespacedName, css)
 
 	if len(nsQuotaExceededList) != 0 {
-		r.Recorder.Event(css, "Warning", "QuotaExceeded", fmt.Sprintf("Exceeded for %d namespaces. Namely: %s", len(nsQuotaExceededList), nsQuotaExceededList))
+		r.Recorder.Event(css, "Warning", "QuotaExceeded", fmt.Sprintf("Not enough available resources for the following %d namespaces: %s", len(nsQuotaExceededList), nsQuotaExceededList))
 	}
 
-	r.Recorder.Event(css, "Normal", "CreatedFinalStates", fmt.Sprintf("The final state for %s namespaces are %s", finalStateNSList, finalStateList))
+	r.Recorder.Event(css, "Normal", "AppliedStates", fmt.Sprintf("The applied state for each of the %s namespaces is %s", finalStateNSList, finalStateList))
 
 	log.Info("Reconciliation loop completed successfully")
 

--- a/controllers/clusterscalingstate_controller.go
+++ b/controllers/clusterscalingstate_controller.go
@@ -18,11 +18,14 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/containersol/prescale-operator/api/v1alpha1"
 	scalingv1alpha1 "github.com/containersol/prescale-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,14 +36,16 @@ import (
 // ClusterScalingStateReconciler reconciles a ClusterScalingState object
 type ClusterScalingStateReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=scaling.prescale.com,resources=clusterscalingstates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=scaling.prescale.com,resources=clusterscalingstates/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=scaling.prescale.com,resources=clusterscalingstates/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -52,7 +57,7 @@ type ClusterScalingStateReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/reconcile
 func (r *ClusterScalingStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-
+	var nsQuotaExceededList []string
 	log := r.Log.
 		WithValues("reconciler kind", "ClusterScalingState").
 		WithValues("reconciler object", req.Name)
@@ -74,12 +79,20 @@ func (r *ClusterScalingStateReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	for _, namespace := range namespaces.Items {
 
-		err = reconciler.ReconcileNamespace(ctx, r.Client, namespace.Name, clusterStateDefinitions, states.State{})
-
+		nsQuotaExceeded, err := reconciler.ReconcileNamespace(ctx, r.Client, namespace.Name, clusterStateDefinitions, states.State{})
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 
+		if nsQuotaExceeded != "" {
+			nsQuotaExceededList = append(nsQuotaExceededList, nsQuotaExceeded)
+		}
+	}
+
+	if len(nsQuotaExceededList) != 0 {
+		css := &v1alpha1.ClusterScalingState{}
+		err = r.Get(ctx, req.NamespacedName, css)
+		r.Recorder.Event(css, "Warning", "QuotaExceeded", fmt.Sprintf("Exceeded for %d namespaces. Namely: %s", len(nsQuotaExceededList), nsQuotaExceededList))
 	}
 
 	log.Info("Reconciliation loop completed successfully")

--- a/controllers/clusterscalingstatedefinition_controller.go
+++ b/controllers/clusterscalingstatedefinition_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,13 +34,15 @@ import (
 // ClusterScalingStateDefinitionReconciler reconciles a ClusterScalingStateDefinition object
 type ClusterScalingStateDefinitionReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=scaling.prescale.com,resources=clusterscalingstatedefinitions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=scaling.prescale.com,resources=clusterscalingstatedefinitions/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=scaling.prescale.com,resources=clusterscalingstatedefinitions/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -73,7 +76,7 @@ func (r *ClusterScalingStateDefinitionReconciler) Reconcile(ctx context.Context,
 
 	for _, namespace := range namespaces.Items {
 
-		err = reconciler.ReconcileNamespace(ctx, r.Client, namespace.Name, clusterStateDefinitions, states.State{})
+		_, err := reconciler.ReconcileNamespace(ctx, r.Client, namespace.Name, clusterStateDefinitions, states.State{})
 
 		if err != nil {
 			return ctrl.Result{}, err

--- a/controllers/clusterscalingstatedefinition_controller.go
+++ b/controllers/clusterscalingstatedefinition_controller.go
@@ -72,6 +72,7 @@ func (r *ClusterScalingStateDefinitionReconciler) Reconcile(ctx context.Context,
 	}
 
 	log.Info("Reconciling")
+
 	namespaces := corev1.NamespaceList{}
 	err = r.Client.List(ctx, &namespaces)
 	if err != nil {

--- a/controllers/clusterscalingstatedefinition_controller.go
+++ b/controllers/clusterscalingstatedefinition_controller.go
@@ -99,10 +99,10 @@ func (r *ClusterScalingStateDefinitionReconciler) Reconcile(ctx context.Context,
 	err = r.Get(ctx, req.NamespacedName, cssd)
 
 	if len(nsQuotaExceededList) != 0 {
-		r.Recorder.Event(cssd, "Warning", "QuotaExceeded", fmt.Sprintf("Exceeded for %d namespaces. Namely: %s", len(nsQuotaExceededList), nsQuotaExceededList))
+		r.Recorder.Event(cssd, "Warning", "QuotaExceeded", fmt.Sprintf("Not enough available resources for the following %d namespaces: %s", len(nsQuotaExceededList), nsQuotaExceededList))
 	}
 
-	r.Recorder.Event(cssd, "Normal", "CreatedFinalStates", fmt.Sprintf("The final state for %s namespaces are %s", finalStateNSList, finalStateList))
+	r.Recorder.Event(cssd, "Normal", "AppliedStates", fmt.Sprintf("The applied state for each of the %s namespaces is %s", finalStateNSList, finalStateList))
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/deploymentConfig_watch_controller.go
+++ b/controllers/deploymentConfig_watch_controller.go
@@ -94,6 +94,6 @@ func (r *DeploymentConfigWatcher) Reconcile(ctx context.Context, req ctrl.Reques
 func (r *DeploymentConfigWatcher) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ocv1.DeploymentConfig{}).
-		WithEventFilter(validations.PreFilter()).
+		WithEventFilter(validations.PreFilter(r.Recorder)).
 		Complete(r)
 }

--- a/controllers/deploymentConfig_watch_controller.go
+++ b/controllers/deploymentConfig_watch_controller.go
@@ -22,6 +22,7 @@ import (
 	ocv1 "github.com/openshift/api/apps/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,12 +34,14 @@ import (
 // DeploymentConfigWatcher reconciles a ScalingState object
 type DeploymentConfigWatcher struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;watch;
 // +kubebuilder:rbac:groups=apps.openshift.io,resources=deploymentconfigs,verbs=get;list;watch;patch;update;
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // WatchForDeploymentConfigs creates watcher for the deploymentconfig objects
 func (r *DeploymentConfigWatcher) WatchForDeploymentConfigs(client client.Client, c controller.Controller) error {

--- a/controllers/deployment_watch_controller.go
+++ b/controllers/deployment_watch_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,12 +34,14 @@ import (
 // DeploymentWatcher reconciles a ScalingState object
 type DeploymentWatcher struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;watch;
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch;update;
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // WatchForDeployments creates watcher for the deployment objects
 func (r *DeploymentWatcher) WatchForDeployments(client client.Client, c controller.Controller) error {

--- a/controllers/deployment_watch_controller.go
+++ b/controllers/deployment_watch_controller.go
@@ -93,6 +93,6 @@ func (r *DeploymentWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ct
 func (r *DeploymentWatcher) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.Deployment{}).
-		WithEventFilter(validations.PreFilter()).
+		WithEventFilter(validations.PreFilter(r.Recorder)).
 		Complete(r)
 }

--- a/controllers/scalingstate_controller.go
+++ b/controllers/scalingstate_controller.go
@@ -69,7 +69,7 @@ func (r *ScalingStateReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	nsQuotaExceeded, state, err := reconciler.ReconcileNamespace(ctx, r.Client, req.Namespace, clusterStateDefinitions, states.State{})
+	events, state, err := reconciler.ReconcileNamespace(ctx, r.Client, req.Namespace, clusterStateDefinitions, states.State{})
 
 	if err != nil {
 		return ctrl.Result{}, err
@@ -78,8 +78,8 @@ func (r *ScalingStateReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	ss := &v1alpha1.ScalingState{}
 	err = r.Get(ctx, req.NamespacedName, ss)
 
-	if nsQuotaExceeded.QuotaExceeded != "" {
-		r.Recorder.Event(ss, "Warning", "QuotaExceeded", fmt.Sprintf("Not enough available resources for namespace %s", nsQuotaExceeded.QuotaExceeded))
+	if events.QuotaExceeded != "" {
+		r.Recorder.Event(ss, "Warning", "QuotaExceeded", fmt.Sprintf("Not enough available resources for namespace %s", events.QuotaExceeded))
 	}
 
 	r.Recorder.Event(ss, "Normal", "AppliedState", fmt.Sprintf("The applied state for this namespace is %s", state))

--- a/controllers/scalingstate_controller.go
+++ b/controllers/scalingstate_controller.go
@@ -79,10 +79,10 @@ func (r *ScalingStateReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	err = r.Get(ctx, req.NamespacedName, ss)
 
 	if nsQuotaExceeded.QuotaExceeded != "" {
-		r.Recorder.Event(ss, "Warning", "QuotaExceeded", fmt.Sprintf("Exceeded for namespace %s", nsQuotaExceeded.QuotaExceeded))
+		r.Recorder.Event(ss, "Warning", "QuotaExceeded", fmt.Sprintf("Not enough available resources for namespace %s", nsQuotaExceeded.QuotaExceeded))
 	}
 
-	r.Recorder.Event(ss, "Normal", "CreatedFinalState", fmt.Sprintf("The final state for this namespace is %s", state))
+	r.Recorder.Event(ss, "Normal", "AppliedState", fmt.Sprintf("The applied state for this namespace is %s", state))
 
 	log.Info("Reconciliation loop completed successfully")
 

--- a/internal/e2e/suite_test.go
+++ b/internal/e2e/suite_test.go
@@ -101,30 +101,34 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&controllers.ClusterScalingStateDefinitionReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ClusterScalingStateDefinition"),
-		Scheme: k8sManager.GetScheme(),
+		Client:   k8sManager.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("ClusterScalingStateDefinition"),
+		Scheme:   k8sManager.GetScheme(),
+		Recorder: k8sManager.GetEventRecorderFor("clusterscalingstatedefinition-controller"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&controllers.ClusterScalingStateReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ClusterScalingState"),
-		Scheme: k8sManager.GetScheme(),
+		Client:   k8sManager.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("ClusterScalingState"),
+		Scheme:   k8sManager.GetScheme(),
+		Recorder: k8sManager.GetEventRecorderFor("clusterscalingstate-controller"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&controllers.ScalingStateReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ScalingState"),
-		Scheme: k8sManager.GetScheme(),
+		Client:   k8sManager.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("ScalingState"),
+		Scheme:   k8sManager.GetScheme(),
+		Recorder: k8sManager.GetEventRecorderFor("scalingstate-controller"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&controllers.DeploymentWatcher{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("DeploymentWatcher"),
-		Scheme: k8sManager.GetScheme(),
+		Client:   k8sManager.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("DeploymentWatcher"),
+		Scheme:   k8sManager.GetScheme(),
+		Recorder: k8sManager.GetEventRecorderFor("deployment-controller"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -132,9 +136,10 @@ var _ = BeforeSuite(func() {
 	c.OpenshiftCluster, err = validations.ClusterCheck()
 	if c.OpenshiftCluster {
 		err = (&controllers.DeploymentConfigWatcher{
-			Client: k8sManager.GetClient(),
-			Log:    ctrl.Log.WithName("controllers").WithName("DeploymentConfigWatcher"),
-			Scheme: k8sManager.GetScheme(),
+			Client:   k8sManager.GetClient(),
+			Log:      ctrl.Log.WithName("controllers").WithName("DeploymentConfigWatcher"),
+			Scheme:   k8sManager.GetScheme(),
+			Recorder: k8sManager.GetEventRecorderFor("deploymentconfig-controller"),
 		}).SetupWithManager(k8sManager)
 		Expect(err).ToNot(HaveOccurred())
 	}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -17,10 +17,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ReconcileNamespace(ctx context.Context, _client client.Client, namespace string, stateDefinitions states.States, clusterState states.State) (string, error) {
+type NamespaceEvents struct {
+	QuotaExceeded string
+}
+
+func ReconcileNamespace(ctx context.Context, _client client.Client, namespace string, stateDefinitions states.States, clusterState states.State) (NamespaceEvents, string, error) {
 
 	var objectsToReconcile int
 	var deploymentConfigs ocv1.DeploymentConfigList
+	var nsEvents NamespaceEvents
 
 	var scaleReplicalistDC []state_replicas.StateReplica
 	var limitsneeded corev1.ResourceList
@@ -33,7 +38,7 @@ func ReconcileNamespace(ctx context.Context, _client client.Client, namespace st
 	finalState, err := GetAppliedState(ctx, _client, namespace, stateDefinitions, clusterState)
 	if err != nil {
 		log.Error(err, "Cannot determine applied state for namespace")
-		return "", err
+		return nsEvents, finalState.Name, err
 	}
 
 	// We now need to look for objects (currently supported deployments and deploymentConfigs) which are opted in,
@@ -41,14 +46,14 @@ func ReconcileNamespace(ctx context.Context, _client client.Client, namespace st
 	deployments, err := resources.DeploymentLister(ctx, _client, namespace, c.OptInLabel)
 	if err != nil {
 		log.Error(err, "Cannot list deployments in namespace")
-		return "", err
+		return nsEvents, finalState.Name, err
 	}
 	objectsToReconcile = objectsToReconcile + len(deployments.Items)
 
 	scaleReplicalist, err := resources.DeploymentStateReplicasList(finalState, deployments)
 	if err != nil {
 		log.Error(err, "Cannot fetch replicas of all opted-in deployments")
-		return "", err
+		return nsEvents, finalState.Name, err
 	}
 
 	//Here we calculate the resource limits we need from all deployments combined
@@ -61,7 +66,7 @@ func ReconcileNamespace(ctx context.Context, _client client.Client, namespace st
 		deploymentConfigs, err = resources.DeploymentConfigLister(ctx, _client, namespace, c.OptInLabel)
 		if err != nil {
 			log.Error(err, "Cannot list deploymentConfigs in namespace")
-			return "", err
+			return nsEvents, finalState.Name, err
 		}
 		objectsToReconcile = objectsToReconcile + len(deploymentConfigs.Items)
 
@@ -69,7 +74,7 @@ func ReconcileNamespace(ctx context.Context, _client client.Client, namespace st
 
 		if err != nil {
 			log.Error(err, "Cannot fetch replicas of all opted-in deploymentconfigs")
-			return "", err
+			return nsEvents, finalState.Name, err
 		}
 
 		//In case of Openshift, we calculate the resource limits we need from all deploymentconfigs combined and we add it to the total number
@@ -81,7 +86,7 @@ func ReconcileNamespace(ctx context.Context, _client client.Client, namespace st
 	allowed, err := quotas.ResourceQuotaCheck(ctx, namespace, limitsneeded)
 	if err != nil {
 		log.Error(err, "Cannot calculate the resource quotas")
-		return "", err
+		return nsEvents, finalState.Name, err
 	}
 
 	log = ctrl.Log.
@@ -112,18 +117,17 @@ func ReconcileNamespace(ctx context.Context, _client client.Client, namespace st
 					continue
 				}
 			}
-
 		}
 	} else {
-		return namespace, err
+		nsEvents.QuotaExceeded = namespace
 	}
 
 	if objectsToReconcile == 0 {
 		log.Info("No objects to reconcile. Doing Nothing.")
-		return "", nil
+		return nsEvents, finalState.Name, err
 	}
 
-	return "", nil
+	return nsEvents, finalState.Name, err
 }
 
 func ReconcileDeployment(ctx context.Context, _client client.Client, deployment v1.Deployment, state states.State) error {

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -84,7 +84,7 @@ func TestReconcileNamespace(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ReconcileNamespace(tt.args.ctx, tt.args._client, tt.args.namespace, tt.args.stateDefinitions, tt.args.clusterState); (err != nil) != tt.wantErr {
+			if _, err := ReconcileNamespace(tt.args.ctx, tt.args._client, tt.args.namespace, tt.args.stateDefinitions, tt.args.clusterState); (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileNamespace() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -84,7 +84,7 @@ func TestReconcileNamespace(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := ReconcileNamespace(tt.args.ctx, tt.args._client, tt.args.namespace, tt.args.stateDefinitions, tt.args.clusterState); (err != nil) != tt.wantErr {
+			if _, _, err := ReconcileNamespace(tt.args.ctx, tt.args._client, tt.args.namespace, tt.args.stateDefinitions, tt.args.clusterState); (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileNamespace() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/main.go
+++ b/main.go
@@ -83,33 +83,37 @@ func main() {
 	}
 
 	if err = (&controllers.ClusterScalingStateDefinitionReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ClusterScalingStateDefinition"),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("ClusterScalingStateDefinition"),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("clusterscalingstatedefinition-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterScalingStateDefinition")
 		os.Exit(1)
 	}
 	if err = (&controllers.ClusterScalingStateReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ClusterScalingState"),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("ClusterScalingState"),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("clusterscalingstate-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterScalingState")
 		os.Exit(1)
 	}
 	if err = (&controllers.ScalingStateReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ScalingState"),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("ScalingState"),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("scalingstate-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ScalingState")
 		os.Exit(1)
 	}
 	if err = (&controllers.DeploymentWatcher{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("DeploymentWatcher"),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("DeploymentWatcher"),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("deployment-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DeploymentWatcher")
 		os.Exit(1)
@@ -122,9 +126,10 @@ func main() {
 	}
 	if c.OpenshiftCluster {
 		if err = (&controllers.DeploymentConfigWatcher{
-			Client: mgr.GetClient(),
-			Log:    ctrl.Log.WithName("controllers").WithName("DeploymentConfigWatcher"),
-			Scheme: mgr.GetScheme(),
+			Client:   mgr.GetClient(),
+			Log:      ctrl.Log.WithName("controllers").WithName("DeploymentConfigWatcher"),
+			Scheme:   mgr.GetScheme(),
+			Recorder: mgr.GetEventRecorderFor("deploymentconfig-controller"),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "DeploymentConfigWatcher")
 			os.Exit(1)


### PR DESCRIPTION
This feature introduces the ability to generate events and register them in the custom objects. The following events are implemented through this PR:

* For cssd, css and ss, we register an event when we exceed quotas in a namespace. For cssd and css, the event message includes all the namespaces that have exceeded the quota check
* For cssd, css and ss we register an event that reports the applied state on the target namespace(s) at the time of creation or update of the object.
* For deployment and deploymentconfigs, we generate an event on the object itself when the deployment has opted-in while previously being opted-out and the opposite. No event is registered if the same opt-in state is maintained.

For now, these events along with the generated logs, should be enough to test things out. As we go on, we can start adding more events which can help us to see how we can create a more generic package.
