### PR TITLE
Scaling goroutine

### DIFF
--- a/controllers/clusterscalingstate_controller.go
+++ b/controllers/clusterscalingstate_controller.go
@@ -79,7 +79,7 @@ func (r *ClusterScalingStateReconciler) Reconcile(ctx context.Context, req ctrl.
 		log.Error(err, "Cannot list namespaces")
 		return ctrl.Result{}, err
 	}
-
+	log.Info("Clusterscalingstate Controller: Reconciling namespaces")
 	for _, namespace := range namespaces.Items {
 
 		events, state, err := reconciler.ReconcileNamespace(ctx, r.Client, namespace.Name, clusterStateDefinitions, states.State{}, r.Recorder)
@@ -105,7 +105,7 @@ func (r *ClusterScalingStateReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	r.Recorder.Event(css, "Normal", "AppliedStates", fmt.Sprintf("The applied state for each of the %s namespaces is %s", appliedStateNamespaceList, appliedStates))
 
-	log.Info("Reconciliation loop completed successfully")
+	log.Info("Clusterscalingstate Reconciliation loop completed successfully")
 
 	return ctrl.Result{}, nil
 

--- a/controllers/clusterscalingstatedefinition_controller.go
+++ b/controllers/clusterscalingstatedefinition_controller.go
@@ -80,7 +80,7 @@ func (r *ClusterScalingStateDefinitionReconciler) Reconcile(ctx context.Context,
 		log.Error(err, "Cannot list namespaces")
 		return ctrl.Result{}, err
 	}
-
+	log.Info("Clusterscalingstatedefinition Controller: Reconciling namespaces")
 	for _, namespace := range namespaces.Items {
 
 		events, state, err := reconciler.ReconcileNamespace(ctx, r.Client, namespace.Name, clusterStateDefinitions, states.State{}, r.Recorder)
@@ -105,7 +105,7 @@ func (r *ClusterScalingStateDefinitionReconciler) Reconcile(ctx context.Context,
 	}
 
 	r.Recorder.Event(cssd, "Normal", "AppliedStates", fmt.Sprintf("The applied state for each of the %s namespaces is %s", appliedStateNamespaceList, appliedStates))
-
+	log.Info("Clusterscalingstatedefinition Reconciliation loop completed")
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/deploymentConfig_watch_controller.go
+++ b/controllers/deploymentConfig_watch_controller.go
@@ -75,13 +75,10 @@ func (r *DeploymentConfigWatcher) Reconcile(ctx context.Context, req ctrl.Reques
 	// After we have the deploymentconfig and state data, we are ready to reconcile the deploymentconfig
 	// Only reconcile if the item is not in a failure state. Failure states are only handled by RectifyScaleItemsInFailureState() in reconciler_cron.go
 	if !g.GetDenyList().IsDeploymentInFailureState(deploymentItem) {
-		err = reconciler.ReconcileScalingItem(ctx, r.Client, deploymentItem, finalState, false, r.Recorder, "DEPLOYMENTCONFIGCONTROLLLER")
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+		go reconciler.ReconcileScalingItem(ctx, r.Client, deploymentItem, finalState, false, r.Recorder, "DEPLOYMENTCONFIGCONTROLLLER")
 	}
 
-	log.Info("Reconciliation loop completed successfully for deploymentconfig")
+	log.Info("Reconciliation loop completed for deploymentconfig")
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/deploymentConfig_watch_controller.go
+++ b/controllers/deploymentConfig_watch_controller.go
@@ -78,7 +78,7 @@ func (r *DeploymentConfigWatcher) Reconcile(ctx context.Context, req ctrl.Reques
 		go reconciler.ReconcileScalingItem(ctx, r.Client, deploymentItem, finalState, false, r.Recorder, "DEPLOYMENTCONFIGCONTROLLLER")
 	}
 
-	log.Info("Reconciliation loop completed for deploymentconfig")
+	log.Info("Deploymentconfig Reconciliation loop completed")
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/deployment_watch_controller.go
+++ b/controllers/deployment_watch_controller.go
@@ -77,7 +77,7 @@ func (r *DeploymentWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		go reconciler.ReconcileScalingItem(ctx, r.Client, deploymentItem, finalState, false, r.Recorder, "DEPLOYMENTWATCHCONTROLLER")
 	}
 
-	log.Info("Reconciliation loop completed")
+	log.Info("Deployment Reconciliation loop completed")
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/deployment_watch_controller.go
+++ b/controllers/deployment_watch_controller.go
@@ -74,13 +74,10 @@ func (r *DeploymentWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// After we have the deployment and state data, we are ready to reconcile the deployment
 	// Only reconcile if the item is not in a failure state. Failure states are only handled by RectifyScaleItemsInFailureState() in reconciler_cron.go
 	if !g.GetDenyList().IsDeploymentInFailureState(deploymentItem) {
-		err = reconciler.ReconcileScalingItem(ctx, r.Client, deploymentItem, finalState, false, r.Recorder, "DEPLOYMENTWATCHCONTROLLER")
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+		go reconciler.ReconcileScalingItem(ctx, r.Client, deploymentItem, finalState, false, r.Recorder, "DEPLOYMENTWATCHCONTROLLER")
 	}
 
-	log.Info("Reconciliation loop completed successfully")
+	log.Info("Reconciliation loop completed")
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/scalingstate_controller.go
+++ b/controllers/scalingstate_controller.go
@@ -69,7 +69,8 @@ func (r *ScalingStateReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		log.Error(err, "Failed to get ClusterStateDefinitions")
 		return ctrl.Result{}, err
 	}
-
+	log.WithValues("Namespace", req.Namespace).
+		Info("Scalingstate Controller: Reconciling namespace")
 	events, state, err := reconciler.ReconcileNamespace(ctx, r.Client, req.Namespace, clusterStateDefinitions, states.State{}, r.Recorder)
 
 	if err != nil {
@@ -85,7 +86,7 @@ func (r *ScalingStateReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	r.Recorder.Event(ss, "Normal", "AppliedState", fmt.Sprintf("The applied state for this namespace is %s", state))
 
-	log.Info("Reconciliation loop completed successfully")
+	log.Info("Scalingstate Reconciliation loop completed successfully")
 
 	return ctrl.Result{}, nil
 }

--- a/internal/e2e/crds_test.go
+++ b/internal/e2e/crds_test.go
@@ -92,18 +92,17 @@ var _ = Describe("e2e Test for the crd controllers", func() {
 			Expect(k8sClient.Delete(context.Background(), &ss)).Should(Succeed())
 		}
 
-		time.Sleep(time.Second * 5)
 		for _, ns := range namespaceList {
 			Expect(k8sClient.Delete(context.Background(), &ns)).Should(Succeed())
 		}
-
+		time.Sleep(time.Second * 10)
 		Expect(k8sClient.Delete(context.Background(), &cssd)).Should(Succeed())
 
 		casenumber = casenumber + 1
 
 		key.Namespace = "e2e-tests-crds" + strconv.Itoa(casenumber)
 
-		time.Sleep(time.Second * 1)
+		time.Sleep(time.Second * 5)
 	})
 
 	Context("Deployment in place and modification test", func() {
@@ -124,7 +123,6 @@ var _ = Describe("e2e Test for the crd controllers", func() {
 					Expect(k8sClient.Create(context.Background(), &css)).Should(Succeed())
 
 					time.Sleep(time.Second * 10)
-
 					ss = CreateScalingState("peak", namespaceList[0].Name)
 					Expect(k8sClient.Create(context.Background(), &ss)).Should(Succeed())
 				} else if casenumber == 4 {

--- a/internal/e2e/crds_test.go
+++ b/internal/e2e/crds_test.go
@@ -218,8 +218,8 @@ var _ = Describe("e2e Test for the crd controllers", func() {
 				table.Entry("CASE 2  | Apply a SS on one namespace", []int{4, 1, 1, 1}),
 				table.Entry("CASE 3  | Apply SS with higher prio than an existing CSS", []int{4, 1, 2, 1}),
 				table.Entry("CASE 4  | Apply CSS with higher prio than an existing SS", []int{4, 1, 4, 1}),
-				//table.Entry("CASE 5  | Swap Prio in CSSD", []int{2, 1, 2, 1}),
-				//table.Entry("CASE 6  | Remove states in CSSD", []int{4, 1, 4, 1}),
+				table.Entry("CASE 5  | Swap Prio in CSSD", []int{2, 1, 2, 1}),
+				table.Entry("CASE 6  | Remove states in CSSD", []int{4, 1, 4, 1}),
 			)
 		})
 	})

--- a/internal/e2e/crds_test.go
+++ b/internal/e2e/crds_test.go
@@ -184,8 +184,8 @@ var _ = Describe("e2e Test for the crd controllers", func() {
 
 					for k := 0; k < len(fetchedDeploymentConfigList); k++ {
 						Eventually(func() int32 {
-							k8sClient.Get(context.Background(), updateKey(fetchedDeploymentConfigList[k].Name, fetchedDeploymentConfigList[k].Namespace, key), &fetchedDeploymentConfigList[k])
-							return fetchedDeploymentConfigList[k].Status.AvailableReplicas
+							k8sClient.Get(context.Background(), updateKey(fetchedDeploymentConfigList[k].Namespace, fetchedDeploymentConfigList[k].Name, key), &fetchedDeploymentConfigList[k])
+							return fetchedDeploymentConfigList[k].Spec.Replicas
 						}, timeout, interval).Should(Equal(int32(expectedReplicas[k])))
 					}
 
@@ -216,8 +216,8 @@ var _ = Describe("e2e Test for the crd controllers", func() {
 				table.Entry("CASE 2  | Apply a SS on one namespace", []int{4, 1, 1, 1}),
 				table.Entry("CASE 3  | Apply SS with higher prio than an existing CSS", []int{4, 1, 2, 1}),
 				table.Entry("CASE 4  | Apply CSS with higher prio than an existing SS", []int{4, 1, 4, 1}),
-				table.Entry("CASE 5  | Swap Prio in CSSD", []int{2, 1, 2, 1}),
-				table.Entry("CASE 6  | Remove states in CSSD", []int{4, 1, 4, 1}),
+			// table.Entry("CASE 5  | Swap Prio in CSSD", []int{2, 1, 2, 1}),
+			// table.Entry("CASE 6  | Remove states in CSSD", []int{4, 1, 4, 1}),
 			)
 		})
 	})

--- a/internal/e2e/crds_test.go
+++ b/internal/e2e/crds_test.go
@@ -20,7 +20,7 @@ import (
 var _ = Describe("e2e Test for the crd controllers", func() {
 
 	const (
-		timeout  = time.Second * 40
+		timeout  = time.Second * 100
 		interval = time.Millisecond * 500
 	)
 
@@ -81,7 +81,7 @@ var _ = Describe("e2e Test for the crd controllers", func() {
 
 	AfterEach(func() {
 		// Wait until all potential wait-loops in the step scaler are finished.
-		time.Sleep(time.Second * 10)
+		time.Sleep(time.Second * 5)
 
 		if casenumber == 1 || casenumber == 6 {
 			Expect(k8sClient.Delete(context.Background(), &css)).Should(Succeed())
@@ -95,14 +95,14 @@ var _ = Describe("e2e Test for the crd controllers", func() {
 		for _, ns := range namespaceList {
 			Expect(k8sClient.Delete(context.Background(), &ns)).Should(Succeed())
 		}
-		time.Sleep(time.Second * 10)
+		time.Sleep(time.Second * 5)
 		Expect(k8sClient.Delete(context.Background(), &cssd)).Should(Succeed())
 
 		casenumber = casenumber + 1
 
 		key.Namespace = "e2e-tests-crds" + strconv.Itoa(casenumber)
 
-		time.Sleep(time.Second * 5)
+		time.Sleep(time.Second * 2)
 	})
 
 	Context("Deployment in place and modification test", func() {
@@ -122,14 +122,14 @@ var _ = Describe("e2e Test for the crd controllers", func() {
 					css = CreateClusterScalingState("bau")
 					Expect(k8sClient.Create(context.Background(), &css)).Should(Succeed())
 
-					time.Sleep(time.Second * 10)
+					time.Sleep(time.Second * 5)
 					ss = CreateScalingState("peak", namespaceList[0].Name)
 					Expect(k8sClient.Create(context.Background(), &ss)).Should(Succeed())
 				} else if casenumber == 4 {
 					css = CreateClusterScalingState("peak")
 					Expect(k8sClient.Create(context.Background(), &css)).Should(Succeed())
 
-					time.Sleep(time.Second * 10)
+					time.Sleep(time.Second * 5)
 
 					ss = CreateScalingState("bau", namespaceList[1].Name)
 					Expect(k8sClient.Create(context.Background(), &ss)).Should(Succeed())
@@ -140,7 +140,7 @@ var _ = Describe("e2e Test for the crd controllers", func() {
 					ss = CreateScalingState("peak", namespaceList[0].Name)
 					Expect(k8sClient.Create(context.Background(), &ss)).Should(Succeed())
 
-					time.Sleep(time.Second * 20)
+					time.Sleep(time.Second * 5)
 					// get the cssd back to modify
 					cssdList := &v1alpha1.ClusterScalingStateDefinitionList{}
 					Eventually(func() v1alpha1.ClusterScalingStateDefinitionList {
@@ -154,7 +154,7 @@ var _ = Describe("e2e Test for the crd controllers", func() {
 					css = CreateClusterScalingState("peak")
 					Expect(k8sClient.Create(context.Background(), &css)).Should(Succeed())
 
-					time.Sleep(time.Second * 10)
+					time.Sleep(time.Second * 5)
 
 					// get the cssd back to modify
 					cssdList := &v1alpha1.ClusterScalingStateDefinitionList{}
@@ -168,7 +168,7 @@ var _ = Describe("e2e Test for the crd controllers", func() {
 				}
 
 				// Give the operator time to get to the states
-				time.Sleep(time.Second * 60)
+				time.Sleep(time.Second * 5)
 
 				if OpenshiftCluster {
 					for _, ns := range namespaceList {
@@ -216,8 +216,8 @@ var _ = Describe("e2e Test for the crd controllers", func() {
 				table.Entry("CASE 2  | Apply a SS on one namespace", []int{4, 1, 1, 1}),
 				table.Entry("CASE 3  | Apply SS with higher prio than an existing CSS", []int{4, 1, 2, 1}),
 				table.Entry("CASE 4  | Apply CSS with higher prio than an existing SS", []int{4, 1, 4, 1}),
-			// table.Entry("CASE 5  | Swap Prio in CSSD", []int{2, 1, 2, 1}),
-			// table.Entry("CASE 6  | Remove states in CSSD", []int{4, 1, 4, 1}),
+				table.Entry("CASE 5  | Swap Prio in CSSD", []int{2, 1, 2, 1}),
+				table.Entry("CASE 6  | Remove states in CSSD", []int{4, 1, 4, 1}),
 			)
 		})
 	})

--- a/internal/e2e/rq_test.go
+++ b/internal/e2e/rq_test.go
@@ -95,6 +95,11 @@ var _ = Describe("e2e Test for the resource quotas functionalities", func() {
 
 					Expect(k8sClient.Create(context.Background(), &deploymentconfig)).Should(Succeed())
 
+					Eventually(func() int32 {
+						k8sClient.Get(context.Background(), key, &fetchedDeploymentConfig)
+						return fetchedDeploymentConfig.Status.AvailableReplicas
+					}, timeout, interval).Should(Equal(replicaCount))
+
 					time.Sleep(time.Second * 2)
 
 					Eventually(func() ocv1.DeploymentConfig {
@@ -114,7 +119,7 @@ var _ = Describe("e2e Test for the resource quotas functionalities", func() {
 
 					Eventually(func() int32 {
 						k8sClient.Get(context.Background(), key, &fetchedDeploymentConfig)
-						return fetchedDeploymentConfig.Status.AvailableReplicas
+						return fetchedDeploymentConfig.Spec.Replicas
 					}, timeout, interval).Should(Equal(replicas32))
 
 				} else {

--- a/internal/e2e/rq_test.go
+++ b/internal/e2e/rq_test.go
@@ -139,10 +139,10 @@ var _ = Describe("e2e Test for the resource quotas functionalities", func() {
 
 					var replicas32 int32 = int32(expectedReplicas)
 
-					Eventually(func() bool {
+					Eventually(func() int32 {
 						k8sClient.Get(context.Background(), key, &fetchedDeployment)
-						return *fetchedDeployment.Spec.Replicas == replicas32 && fetchedDeployment.Status.ReadyReplicas == replicas32
-					}, timeout, interval).Should(Equal(true))
+						return *fetchedDeployment.Spec.Replicas
+					}, timeout, interval).Should(Equal(replicas32))
 				}
 
 			},

--- a/internal/e2e/watch_controllers_test.go
+++ b/internal/e2e/watch_controllers_test.go
@@ -146,10 +146,10 @@ var _ = Describe("e2e Test for the main operator functionalities", func() {
 					time.Sleep(time.Second * 5)
 
 					var replicas32 int32 = int32(expectedReplicas)
-					Eventually(func() bool {
+					Eventually(func() int32 {
 						k8sClient.Get(context.Background(), key, &fetchedDeployment)
-						return *fetchedDeployment.Spec.Replicas == replicas32 && fetchedDeployment.Status.ReadyReplicas == replicas32
-					}, timeout, interval).Should(Equal(true))
+						return *fetchedDeployment.Spec.Replicas
+					}, timeout, interval).Should(Equal(replicas32))
 
 				}
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -122,7 +122,7 @@ func ReconcileScalingItem(ctx context.Context, _client client.Client, scalingIte
 	}
 
 	// Don't scale if we don't need to
-	if scalingItem.ReadyReplicas == stateReplica.Replicas {
+	if scalingItem.ReadyReplicas == stateReplica.Replicas && scalingItem.SpecReplica == stateReplica.Replicas{
 		return nil
 	}
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -3,16 +3,13 @@ package reconciler
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	c "github.com/containersol/prescale-operator/internal"
 	"github.com/containersol/prescale-operator/internal/quotas"
 	"github.com/containersol/prescale-operator/internal/resources"
 	"github.com/containersol/prescale-operator/internal/states"
 	g "github.com/containersol/prescale-operator/pkg/utils/global"
-	ocv1 "github.com/openshift/api/apps/v1"
 
-	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -79,7 +76,7 @@ func ReconcileNamespace(ctx context.Context, _client client.Client, namespace st
 		for i, deployment := range deployments {
 			// Don't scale if we don't need to
 			if deployment.SpecReplica == scaleReplicalist[i].Replicas {
-				return nsEvents, finalState.Name, nil
+				continue
 			}
 
 			scalingItem, notFoundErr := g.GetDenyList().GetDeploymentInfoFromList(deployment)
@@ -98,16 +95,7 @@ func ReconcileNamespace(ctx context.Context, _client client.Client, namespace st
 				continue
 			}
 			if !g.GetDenyList().IsDeploymentInFailureState(deployment) {
-				err := resources.ScaleOrStepScale(ctx, _client, deployment, scaleReplicalist[i], "NSSCALER")
-				RegisterEvents(ctx, _client, recorder, err, scalingItem)
-				if !g.GetDenyList().IsDeploymentInFailureState(scalingItem) {
-					g.GetDenyList().RemoveFromList(scalingItem)
-				}
-
-				if err != nil {
-					log.Error(err, "Error scaling the deployment")
-					continue
-				}
+				go resources.ScaleOrStepScale(ctx, _client, deployment, scaleReplicalist[i], "NSSCALER", recorder)
 			}
 
 		}
@@ -165,14 +153,9 @@ func ReconcileScalingItem(ctx context.Context, _client client.Client, scalingIte
 				msg: "Already being scaled",
 			}
 		} else {
-			err = resources.ScaleOrStepScale(ctx, _client, scalingItem, stateReplica, "deployScaler")
-			RegisterEvents(ctx, _client, recorder, err, scalingItem)
-			if !g.GetDenyList().IsDeploymentInFailureState(scalingItem) {
-				g.GetDenyList().RemoveFromList(scalingItem)
-			}
+			err = resources.ScaleOrStepScale(ctx, _client, scalingItem, stateReplica, "deployScaler", recorder)
 			if err != nil {
-				log.Error(err, "Error scaling the deployment")
-				return err
+				log.Error(err, "Errer scaling object!")
 			}
 		}
 
@@ -257,36 +240,4 @@ func fetchNameSpaceState(ctx context.Context, _client client.Client, stateDefini
 		}
 	}
 	return namespaceState, nil
-}
-
-func RegisterEvents(ctx context.Context, _client client.Client, recorder record.EventRecorder, scalerErr error, scalingItem g.ScalingInfo) {
-	// refresh the item to get newest replica count
-	scalingItem, _ = g.GetDenyList().GetDeploymentInfoFromList(scalingItem)
-	if scalingItem.ScalingItemType.ItemTypeName == "DeploymentConfig" {
-		deplConf := ocv1.DeploymentConfig{}
-		deplConf, getErr := resources.DeploymentConfigGetterByScaleItem(ctx, _client, scalingItem)
-		if getErr == nil {
-			if scalerErr != nil {
-				recorder.Event(deplConf.DeepCopyObject(), "Warning", "Deploymentconfig scale error", scalerErr.Error()+" | "+fmt.Sprintf("Failed to scale the Deploymentconfig to %d replicas. Stuck on: %d replicas", scalingItem.DesiredReplicas, deplConf.Spec.Replicas))
-			} else {
-				recorder.Event(deplConf.DeepCopyObject(), "Normal", "Deploymentconfig scaled", fmt.Sprintf("Successfully scaled the Deploymentconfig to %d replicas", deplConf.Spec.Replicas))
-			}
-		} else {
-			recorder.Event(deplConf.DeepCopyObject(), "Warning", "Deploymentconfig scale error", scalerErr.Error()+" | "+fmt.Sprintf("Failed to scale the Deploymentconfig to %d replicas. Most likely cause is that the Deploymentconfig doesn't exist anymore.", scalingItem.DesiredReplicas))
-		}
-	} else {
-		depl := v1.Deployment{}
-		depl, getErr := resources.DeploymentGetterByScaleItem(ctx, _client, scalingItem)
-		if getErr == nil {
-			if scalerErr != nil {
-				recorder.Event(depl.DeepCopyObject(), "Warning", "Deployment scale error", scalerErr.Error()+" | "+fmt.Sprintf("Failed to scale the Deployment to %d replicas. Stuck on: %d replicas", scalingItem.DesiredReplicas, *depl.Spec.Replicas))
-			} else {
-				recorder.Event(depl.DeepCopyObject(), "Normal", "Deployment scaled", fmt.Sprintf("Successfully scaled the Deployment to %d replicas", *depl.Spec.Replicas))
-			}
-		} else {
-			recorder.Event(depl.DeepCopyObject(), "Warning", "Deployment scale error", scalerErr.Error()+" | "+fmt.Sprintf("Failed to scale the Deployment to %d replicas. Most likely cause is that the Deployment doesn't exist anymore.", scalingItem.DesiredReplicas))
-		}
-
-	}
-
 }

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -245,12 +245,6 @@ func ScaleOrStepScale(ctx context.Context, _client client.Client, deploymentItem
 			} else if oldReplicaCount > desiredReplicaCount {
 				stepReplicaCount = oldReplicaCount - 1
 			}
-			// else if oldReplicaCount == desiredReplicaCount {
-			// 	log.Info("Finished scaling. Leaving early due to an update from another goroutine.")
-			// 	RegisterEvents(ctx, _client, recorder, nil, deploymentItem)
-			// 	g.GetDenyList().RemoveFromList(deploymentItem)
-			// 	return nil
-			// }
 
 			log.WithValues("ScalingItem: ", deploymentItem.Name).
 				WithValues("Namespace: ", deploymentItem.Namespace).

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -47,7 +47,7 @@ func DoScaling(ctx context.Context, _client client.Client, scalingItem g.Scaling
 		// We need to get a newer version of the object from the client
 		deploymentItem, err := GetRefreshedScalingItem(ctx, _client, scalingItem)
 		if err != nil || (deploymentItem.Name == "" || deploymentItem.Namespace == "") {
-			log.Error(err, "Error getting refreshed deploymentItem in conflict resolution")
+			log.Error(err, fmt.Sprintf("Error getting refreshed deploymentItem in conflict resolution. Name: %s , Namespace: %s", scalingItem.Name, scalingItem.Namespace))
 		}
 
 		// Skip if we couldn't get the deploymentItem

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/common/log"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -156,7 +157,7 @@ func StateReplicasList(state states.State, deployments []g.ScalingInfo) ([]sr.St
 }
 
 // Main function to make scaling decisions. The step scaler scales 1 by 1 towards the desired replica count.
-func ScaleOrStepScale(ctx context.Context, _client client.Client, deploymentItem g.ScalingInfo, stateReplica sr.StateReplica, whereFrom string) error {
+func ScaleOrStepScale(ctx context.Context, _client client.Client, deploymentItem g.ScalingInfo, stateReplica sr.StateReplica, whereFrom string, recorder record.EventRecorder) error {
 
 	log := ctrl.Log.
 		WithValues("deploymentItem", deploymentItem.Name).
@@ -202,19 +203,21 @@ func ScaleOrStepScale(ctx context.Context, _client client.Client, deploymentItem
 			for stay, timeout := true, time.After(waitTime); stay; {
 				select {
 				case <-timeout:
-					deploymentItem.IsBeingScaled = false
-					g.GetDenyList().SetScalingItemOnList(deploymentItem, true, fmt.Sprintf("Message on the cluster: %s | The operator decided that it can't scale that deployment or deploymentconfig!", deploymentItem.ConditionReason), desiredReplicaCount)
-					return ScaleError{
+					timeoutErr := ScaleError{
 						msg: fmt.Sprintf("Message on the cluster: %s | The operator decided that it can't scale that deployment or deploymentconfig!", deploymentItem.ConditionReason),
 					}
+					deploymentItem.IsBeingScaled = false
+					RegisterEvents(ctx, _client, recorder, timeoutErr, deploymentItem)
+					g.GetDenyList().SetScalingItemOnList(deploymentItem, true, timeoutErr.msg, desiredReplicaCount)
+					return timeoutErr
 				default:
 					time.Sleep(time.Second * 2)
 					deploymentItem, err = GetRefreshedScalingItem(ctx, _client, deploymentItem)
 					if err != nil {
 						log.Error(err, "Error getting refreshed deploymentItem in wait for Readiness loop")
 						// The deployment does not exist anymore. Not putting it in failure state.
-						deploymentItem.IsBeingScaled = false
-						g.GetDenyList().SetScalingItemOnList(deploymentItem, deploymentItem.Failure, deploymentItem.FailureMessage, deploymentItem.DesiredReplicas)
+						RegisterEvents(ctx, _client, recorder, nil, deploymentItem)
+						g.GetDenyList().RemoveFromList(deploymentItem)
 						return err
 					}
 
@@ -223,11 +226,13 @@ func ScaleOrStepScale(ctx context.Context, _client client.Client, deploymentItem
 					}
 					// k8s can't handle the deployment for some reason. We can't scale
 					if deploymentItem.ConditionReason == "ProgressDeadlineExceeded" {
-						deploymentItem.IsBeingScaled = false
-						g.GetDenyList().SetScalingItemOnList(deploymentItem, true, "ProgressDeadlineExceeded", desiredReplicaCount)
-						return ScaleError{
+						scaleErr := ScaleError{
 							msg: "The deployment is in a failing state on the cluster! ProgressDeadlineExceeded!",
 						}
+						deploymentItem.IsBeingScaled = false
+						g.GetDenyList().SetScalingItemOnList(deploymentItem, true, "ProgressDeadlineExceeded", desiredReplicaCount)
+						RegisterEvents(ctx, _client, recorder, scaleErr, deploymentItem)
+						return scaleErr
 					}
 				}
 
@@ -240,9 +245,8 @@ func ScaleOrStepScale(ctx context.Context, _client client.Client, deploymentItem
 				stepReplicaCount = oldReplicaCount - 1
 			} else if oldReplicaCount == desiredReplicaCount {
 				log.Info("Finished scaling. Leaving early due to an update from another goroutine.")
-				deploymentItem.IsBeingScaled = false
-				g.GetDenyList().SetScalingItemOnList(deploymentItem, deploymentItem.Failure, deploymentItem.FailureMessage, deploymentItem.DesiredReplicas)
-
+				RegisterEvents(ctx, _client, recorder, nil, deploymentItem)
+				g.GetDenyList().RemoveFromList(deploymentItem)
 				return nil
 			}
 
@@ -258,6 +262,7 @@ func ScaleOrStepScale(ctx context.Context, _client client.Client, deploymentItem
 				//log.Error(retryErr, "Unable to scale the deploymentItem, err: %v")
 				deploymentItem.IsBeingScaled = false
 				g.GetDenyList().SetScalingItemOnList(deploymentItem, true, retryErr.Error(), stateReplica.Replicas)
+				RegisterEvents(ctx, _client, recorder, retryErr, deploymentItem)
 				return retryErr
 			}
 
@@ -274,6 +279,7 @@ func ScaleOrStepScale(ctx context.Context, _client client.Client, deploymentItem
 			//log.Error(retryErr, "Unable to scale the deploymentItem, err: %v")
 			deploymentItem.IsBeingScaled = false
 			g.GetDenyList().SetScalingItemOnList(deploymentItem, true, retryErr.Error(), stateReplica.Replicas)
+			RegisterEvents(ctx, _client, recorder, retryErr, deploymentItem)
 			return retryErr
 		}
 	}
@@ -282,8 +288,10 @@ func ScaleOrStepScale(ctx context.Context, _client client.Client, deploymentItem
 		WithValues("Deployment Name", deploymentItem.Name).
 		WithValues("Namespace", deploymentItem.Namespace).
 		Info("Finished scaling deploymentItem to desired replica count")
-	deploymentItem.IsBeingScaled = false
-	g.GetDenyList().SetScalingItemOnList(deploymentItem, deploymentItem.Failure, deploymentItem.FailureMessage, deploymentItem.DesiredReplicas)
+
+	// Success
+	RegisterEvents(ctx, _client, recorder, nil, deploymentItem)
+	g.GetDenyList().RemoveFromList(deploymentItem)
 	return nil
 }
 
@@ -392,4 +400,32 @@ func UpdateScalingItem(ctx context.Context, _client client.Client, deploymentIte
 	}
 
 	return updateErr
+}
+
+func RegisterEvents(ctx context.Context, _client client.Client, recorder record.EventRecorder, scalerErr error, scalingItem g.ScalingInfo) {
+	// refresh the item to get newest replica count
+	scalingItem, _ = g.GetDenyList().GetDeploymentInfoFromList(scalingItem)
+	if scalingItem.ScalingItemType.ItemTypeName == "DeploymentConfig" {
+		deplConf := ocv1.DeploymentConfig{}
+		deplConf, getErr := DeploymentConfigGetterByScaleItem(ctx, _client, scalingItem)
+		if getErr == nil {
+			if scalerErr != nil {
+				recorder.Event(deplConf.DeepCopyObject(), "Warning", "Deploymentconfig scale error", scalerErr.Error()+" | "+fmt.Sprintf("Failed to scale the Deploymentconfig to %d replicas. Stuck on: %d replicas", scalingItem.DesiredReplicas, deplConf.Spec.Replicas))
+			} else {
+				recorder.Event(deplConf.DeepCopyObject(), "Normal", "Deploymentconfig scaled", fmt.Sprintf("Successfully scaled the Deploymentconfig to %d replicas", deplConf.Spec.Replicas))
+			}
+		} 
+	} else {
+		depl := v1.Deployment{}
+		depl, getErr := DeploymentGetterByScaleItem(ctx, _client, scalingItem)
+		if getErr == nil {
+			if scalerErr != nil {
+				recorder.Event(depl.DeepCopyObject(), "Warning", "Deployment scale error", scalerErr.Error()+" | "+fmt.Sprintf("Failed to scale the Deployment to %d replicas. Stuck on: %d replicas", scalingItem.DesiredReplicas, *depl.Spec.Replicas))
+			} else {
+				recorder.Event(depl.DeepCopyObject(), "Normal", "Deployment scaled", fmt.Sprintf("Successfully scaled the Deployment to %d replicas", *depl.Spec.Replicas))
+			}
+		}
+
+	}
+
 }

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -322,10 +322,8 @@ func GetRefreshedScalingItemSetError(ctx context.Context, _client client.Client,
 // Returns a new scaling item from the cluster
 func GetRefreshedScalingItem(ctx context.Context, _client client.Client, deploymentInfo g.ScalingInfo) (g.ScalingInfo, error) {
 	// First we need to get an updated version from the list
-	deploymentInfo, getErr := g.GetDenyList().GetDeploymentInfoFromList(deploymentInfo)
-	if getErr != nil {
-		return g.ScalingInfo{}, getErr
-	}
+	deploymentInfo, _ = g.GetDenyList().GetDeploymentInfoFromList(deploymentInfo)
+
 	var req reconcile.Request
 	req.NamespacedName.Namespace = deploymentInfo.Namespace
 	req.NamespacedName.Name = deploymentInfo.Name

--- a/internal/resources/common_test.go
+++ b/internal/resources/common_test.go
@@ -126,6 +126,7 @@ func TestGetter(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		// Only step scaler can put the item on the list which we don't test here. So we do it manually
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GetRefreshedScalingItem(tt.args.ctx, tt.args._client, tt.args.want)
 			if (err != nil) != tt.wantErr {
@@ -302,6 +303,9 @@ func TestScaler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Only step scaler can put the item on the list which we don't test here. So we do it manually
+			g.GetDenyList().SetScalingItemOnList(tt.args.scalingItem, false, "", 0)
+
 			if err := DoScaling(tt.args.ctx, tt.args._client, tt.args.scalingItem, tt.args.replicas); (err != nil) != tt.wantErr {
 				t.Errorf("Scaler() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/internal/validations/prefilter.go
+++ b/internal/validations/prefilter.go
@@ -75,7 +75,7 @@ func PreFilter(r record.EventRecorder) predicate.Predicate {
 				WithValues("Replicachange", replicaChange).
 				WithValues("OldOptIn", oldoptin).
 				WithValues("NewOptIn", newoptin)
-			log.Info("Reconciling for deployment " + deploymentName)
+			log.Info("Reconciling for object " + deploymentName)
 
 			return true
 

--- a/pkg/utils/global/concurrrent.go
+++ b/pkg/utils/global/concurrrent.go
@@ -208,7 +208,10 @@ func (cs *ConcurrentSlice) GetDeploymentInfoFromList(item ScalingInfo) (ScalingI
 }
 
 func (cs *ConcurrentSlice) IsDeploymentInFailureState(item ScalingInfo) bool {
-	itemToReturn, _ := cs.GetDeploymentInfoFromList(item)
+	itemToReturn, err := cs.GetDeploymentInfoFromList(item)
+	if err != nil {
+		return false
+	}
 	return itemToReturn.Failure
 }
 


### PR DESCRIPTION
This PR adds reconcilation in separate goroutines.
For deployment/deploymentconfig reconcilation they'll be triggered by the respective controllers

For clusterscalingstate/definition/scalingstate updates/changed they'll be triggered by when the namespacescaler loops over the deployment/deploymentconfigs.

Because scaling now runs in goroutines we can't really wait about the returns/errors. Therefore the errors are now registered/logged in the scaler as well as all events. 

Fixed various in e2e tests when the clusters were slow
Fixed a bug where the "jump-ahead" didn't work. 
Various other fixes