### PR TITLE
Fix missing states

### DIFF
--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -219,7 +219,7 @@ func GetAppliedState(ctx context.Context, _client client.Client, namespace strin
 	}
 
 	if namespaceState == (states.State{}) && clusterState == (states.State{}) {
-		return states.State{}, err
+		return states.State{}, errors.New("could not determine the final state. Do the states match the state definitions?")
 	}
 
 	finalState := stateDefinitions.FindPriorityState(namespaceState, clusterState)

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -269,7 +269,8 @@ func fetchNameSpaceState(ctx context.Context, _client client.Client, stateDefini
 			ctrl.Log.
 				V(3).
 				WithValues("state name", namespaceStateName).
-				Error(err, "Could not find ScalingState within ClusterStateDefinitions. Continuing without considering ScalingState.")
+				Error(err, fmt.Sprintf("Could not find ScalingState %s within ClusterStateDefinitions. Continuing without considering ScalingState.", namespaceStateName))
+			return states.State{}, err
 		}
 	}
 	return namespaceState, nil

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -80,7 +80,7 @@ func TestReconcileNamespace(t *testing.T) {
 				},
 				clusterState: states.State{},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 

--- a/internal/state_replicas/state_replicas.go
+++ b/internal/state_replicas/state_replicas.go
@@ -47,7 +47,7 @@ func (sr *StateReplicas) GetState(name string) (StateReplica, error) {
 			return state, nil
 		}
 	}
-	return StateReplica{}, errors.New("no state found")
+	return StateReplica{}, errors.New(fmt.Sprintf("Could not find state: %s", name))
 }
 
 func NewStateReplicasFromAnnotations(annotations map[string]string) (StateReplicas, error) {

--- a/internal/states/scaling_states.go
+++ b/internal/states/scaling_states.go
@@ -46,7 +46,7 @@ func (s States) FindState(name string, _state *State) error {
 			return nil
 		}
 	}
-	return NotFound{msg: "Could not find state"}
+	return NotFound{msg: fmt.Sprintf("Could not find state: %s", name)}
 }
 
 func (s States) FindPriorityState(a State, b State) State {


### PR DESCRIPTION
When there are scalingstates and clusterscalingstates now specified which are not defined by the clusterscalingstatedefinition the reconcilation will terminate with an error and the respective controller will exit with the error. 


Fixes #79 