### PR TITLE
Added time prefilter that prevents trigger on controller upon startup

### DIFF
--- a/controllers/clusterscalingstate_controller.go
+++ b/controllers/clusterscalingstate_controller.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/containersol/prescale-operator/internal/reconciler"
 	"github.com/containersol/prescale-operator/internal/states"
+	"github.com/containersol/prescale-operator/internal/validations"
 )
 
 // ClusterScalingStateReconciler reconciles a ClusterScalingState object
@@ -141,6 +142,7 @@ func (r *ClusterScalingStateReconciler) SetupWithManager(mgr ctrl.Manager) error
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&scalingv1alpha1.ClusterScalingState{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		WithEventFilter(validations.StartupFilter()).
 		Owns(&scalingv1alpha1.ScalingState{}).
 		Complete(r)
 }

--- a/controllers/clusterscalingstatedefinition_controller.go
+++ b/controllers/clusterscalingstatedefinition_controller.go
@@ -123,7 +123,7 @@ func (r *ClusterScalingStateDefinitionReconciler) Reconcile(ctx context.Context,
 			r.Recorder.Event(cssd, "Warning", "QuotaExceeded", fmt.Sprintf("Not enough available resources for the following %d namespaces: %s", len(eventsList), eventsList))
 		}
 
-		r.Recorder.Event(cssd, "Normal", "AppliedStates", fmt.Sprintf("The applied state for each of the %s namespaces is %s seconds", appliedStateNamespaceList, appliedStates))
+		r.Recorder.Event(cssd, "Normal", "AppliedStates", fmt.Sprintf("The applied state for each of the %s namespaces is %s ", appliedStateNamespaceList, appliedStates))
 		log.Info("Clusterscalingstatedefinition Reconciliation loop completed")
 
 	} else {
@@ -137,7 +137,7 @@ func (r *ClusterScalingStateDefinitionReconciler) Reconcile(ctx context.Context,
 	}
 
 	// Trigger again in order to catch resources which have been created or updated within the first 10 seconds of startup
-	if time.Since(constants.StartTime).Seconds() < 10 {
+	if time.Since(constants.StartTime).Seconds() < 12 {
 		log.Info("Startup complete. Retriggering ClusterScalingStateDefinitionController one more time")
 		return ctrl.Result{RequeueAfter: time.Second * c.RetriggerControllerSeconds}, nil
 	}

--- a/controllers/clusterscalingstatedefinition_controller.go
+++ b/controllers/clusterscalingstatedefinition_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containersol/prescale-operator/api/v1alpha1"
 	scalingv1alpha1 "github.com/containersol/prescale-operator/api/v1alpha1"
 	c "github.com/containersol/prescale-operator/internal"
+	constants "github.com/containersol/prescale-operator/internal"
 	"github.com/containersol/prescale-operator/internal/reconciler"
 	"github.com/containersol/prescale-operator/internal/states"
 )
@@ -132,6 +133,12 @@ func (r *ClusterScalingStateDefinitionReconciler) Reconcile(ctx context.Context,
 	}
 	if retrigger {
 		log.Info(fmt.Sprintf("Not all namespaces reconciled. Retriggering ClusterScalingStateDefinitionController in %d", c.RetriggerControllerSeconds))
+		return ctrl.Result{RequeueAfter: time.Second * c.RetriggerControllerSeconds}, nil
+	}
+
+	// Trigger again in order to catch resources which have been created or updated within the first 10 seconds of startup
+	if time.Since(constants.StartTime).Seconds() < 10 {
+		log.Info("Startup complete. Retriggering ClusterScalingStateDefinitionController one more time")
 		return ctrl.Result{RequeueAfter: time.Second * c.RetriggerControllerSeconds}, nil
 	}
 

--- a/controllers/deploymentConfig_watch_controller.go
+++ b/controllers/deploymentConfig_watch_controller.go
@@ -88,6 +88,7 @@ func (r *DeploymentConfigWatcher) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ocv1.DeploymentConfig{}).
 		WithEventFilter(validations.PreFilter(r.Recorder)).
+		WithEventFilter(validations.StartupFilter()).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)
 }

--- a/controllers/deployment_watch_controller.go
+++ b/controllers/deployment_watch_controller.go
@@ -87,6 +87,7 @@ func (r *DeploymentWatcher) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.Deployment{}).
 		WithEventFilter(validations.PreFilter(r.Recorder)).
+		WithEventFilter(validations.StartupFilter()).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)
 }

--- a/controllers/scalingstate_controller.go
+++ b/controllers/scalingstate_controller.go
@@ -31,6 +31,7 @@ import (
 	scalingv1alpha1 "github.com/containersol/prescale-operator/api/v1alpha1"
 	"github.com/containersol/prescale-operator/internal/reconciler"
 	"github.com/containersol/prescale-operator/internal/states"
+	"github.com/containersol/prescale-operator/internal/validations"
 )
 
 // ScalingStateReconciler reconciles a ScalingState object
@@ -109,6 +110,7 @@ func (r *ScalingStateReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r *ScalingStateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&scalingv1alpha1.ScalingState{}).
+		WithEventFilter(validations.StartupFilter()).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Owns(&scalingv1alpha1.ClusterScalingState{}).
 		Complete(r)

--- a/controllers/scalingstate_controller.go
+++ b/controllers/scalingstate_controller.go
@@ -111,7 +111,7 @@ func (r *ScalingStateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&scalingv1alpha1.ScalingState{}).
 		WithEventFilter(validations.StartupFilter()).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 5}).
 		Owns(&scalingv1alpha1.ClusterScalingState{}).
 		Complete(r)
 }

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -1,8 +1,10 @@
 package internal
 
+import "time"
+
 const (
 	//LabelNotFound is the message for when the label doesn't exist in the application manifest
-	LabelNotFound = "Opt-in label was not found"
+	LabelNotFound = "opt-in label was not found"
 
 	RQNotFound = "No resource quotas found"
 
@@ -29,4 +31,6 @@ var (
 
 	//OpenshiftCluster is used to identify if the operator is running in an Openshift cluster
 	OpenshiftCluster bool
+
+	StartTime time.Time
 )

--- a/internal/e2e/suite_test.go
+++ b/internal/e2e/suite_test.go
@@ -146,6 +146,7 @@ var _ = BeforeSuite(func() {
 		}).SetupWithManager(k8sManager)
 		Expect(err).ToNot(HaveOccurred())
 	}
+	constants.StartTime = time.Now()
 
 	godotenv.Load("../../.env")
 	go func() {

--- a/internal/validations/prefilter.go
+++ b/internal/validations/prefilter.go
@@ -3,7 +3,9 @@ package validations
 import (
 	"fmt"
 	"reflect"
+	"time"
 
+	constants "github.com/containersol/prescale-operator/internal"
 	"github.com/containersol/prescale-operator/pkg/utils/annotations"
 	g "github.com/containersol/prescale-operator/pkg/utils/global"
 	"github.com/containersol/prescale-operator/pkg/utils/labels"
@@ -81,6 +83,12 @@ func PreFilter(r record.EventRecorder) predicate.Predicate {
 
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
+
+			uptime := time.Since(constants.StartTime)
+			if uptime.Seconds() < 5 {
+				return false
+			}
+
 			newlabels := e.Object.GetLabels()
 
 			newoptin := labels.GetLabelValue(newlabels, "scaler/opt-in")

--- a/internal/validations/time_prefilter.go
+++ b/internal/validations/time_prefilter.go
@@ -12,7 +12,11 @@ import (
 func StartupFilter() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return time.Since(constants.StartTime).Seconds() < 10
+			startTime := constants.StartTime
+			if time.Since(startTime).Seconds() < 10 {
+				return false
+			}
+			return true
 		},
 	}
 }

--- a/internal/validations/time_prefilter.go
+++ b/internal/validations/time_prefilter.go
@@ -1,0 +1,18 @@
+package validations
+
+import (
+	"time"
+
+	constants "github.com/containersol/prescale-operator/internal"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// Time PreFilter prevents controllers with this prefilter within the first 10 seconds of startup of being triggered
+func StartupFilter() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return time.Since(constants.StartTime).Seconds() < 10
+		},
+	}
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	"github.com/containersol/prescale-operator/internal/validations"
 	"github.com/joho/godotenv"
@@ -154,6 +155,8 @@ func main() {
 	z.Start()
 
 	godotenv.Load("./.env")
+
+	constants.StartTime = time.Now()
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION

New time prefilter to prevent trigger upon startup.

We only need one initial reconcilation loop upon startup. (We're using the ClusterScalingStateDefinition loop to reconcile the whole cluster initially). All other controllers are "disabled" for the first 10 seconds withing startup. This needs to be done because all **pre-exising** resources in the cluster will all be registered with a "create" event by the operator framework. That'll trigger a lot of unintended reconciles which we don't need. (We only need one over-arching loop from the cluster resources). 

If there is a resource updated or created during this startup period (10 seconds) they'll be reconciled with an additional trigger at the end of the clusterscalingstatedefinitioncontrolller.

